### PR TITLE
ci: automated workflow updates

### DIFF
--- a/.github/workflows/_auto-release.yml
+++ b/.github/workflows/_auto-release.yml
@@ -22,10 +22,10 @@ jobs:
     name: Bump Major Version to Current
     if: needs.release.outputs.version != '' && github.ref_name == 'main'
     needs: release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
     - name: Set Major Version to the current Release
       env:

--- a/.github/workflows/_make-docs.yml
+++ b/.github/workflows/_make-docs.yml
@@ -16,11 +16,11 @@ jobs:
     name: Make Docs
     permissions:
       contents: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
 
       - name: Make Docs
         run: |
@@ -29,7 +29,7 @@ jobs:
         working-directory: ./script/make-docs
 
       - name: Wait for Release job
-        uses: lewagon/wait-on-check-action@74049309dfeff245fe8009a0137eacf28136cb3c # v1.5.0
+        uses: lewagon/wait-on-check-action@a08fbe2b86f9336198f33be6ad9c16b96f92799c # v1
         with:
           ref: ${{ github.ref }}
           check-name: 'Release / Semantic Release'

--- a/.github/workflows/_test-npm-publish.yml
+++ b/.github/workflows/_test-npm-publish.yml
@@ -83,7 +83,7 @@ jobs:
     name: "Unpublish Packages"
     if: always()
     needs: [publish-packed, publish-nopack]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - run: echo -n | gh api --method DELETE "users/dawilk/packages/npm/test-npm-publish" --input -
       env:

--- a/.github/workflows/_validate-workflows.yml
+++ b/.github/workflows/_validate-workflows.yml
@@ -15,11 +15,11 @@ jobs:
     name: Validate Workflows
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: ${{ vars.NODE_VERSION_DEFAULT }}
           cache: 'npm'

--- a/.github/workflows/npm-pack.yml
+++ b/.github/workflows/npm-pack.yml
@@ -123,17 +123,17 @@ defaults:
 jobs:
   pack:
     name: NPM Pack
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       package-filename: ${{ steps.pack.outputs.package-filename }}
       package-tag: ${{ steps.pack.outputs.package-tag }}
       package-version: ${{ steps.version.outputs.package-version }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
     - name: Setup Node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
       with:
         node-version: ${{ inputs.node-version }}
         node-version-file: ${{ inputs.node-version-file }}
@@ -155,7 +155,7 @@ jobs:
         npm config set $URL/:_authToken ${{inputs.private-registry-token}}
 
     - name: Cache dependencies
-      uses: actions/cache@v5
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
       id: cache-modules
       with:
         path: ${{ inputs.cache-modules-path }}
@@ -206,7 +206,7 @@ jobs:
 
     - name: Upload Artifact
       if: ${{ inputs.upload-artifact && steps.pack.outputs.package-filename != '' }}
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         retention-days: ${{ inputs.artifact-retention-days }}
         path: ${{ inputs.working-directory }}/${{ steps.pack.outputs.package-filename }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -128,13 +128,13 @@ defaults:
 jobs:
   publish:
     name: NPM Publish
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
     - name: Setup Node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
       with:
         node-version: ${{ inputs.node-version }}
         node-version-file: ${{ inputs.node-version-file }}
@@ -157,7 +157,7 @@ jobs:
 
     - name: Cache dependencies
       if: ${{ !inputs.download-artifact }}
-      uses: actions/cache@v5
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
       id: cache-modules
       with:
         path: ${{ inputs.cache-modules-path }}
@@ -214,7 +214,7 @@ jobs:
         echo "* Tag: @ $PACKAGE_TAG" >> $GITHUB_STEP_SUMMARY
 
     - name: Download Artifact
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       if: ${{ inputs.download-artifact }}
       with:
         path: ${{ github.workspace }}/artifact-${{ github.sha }}

--- a/.github/workflows/npm-run-script.yml
+++ b/.github/workflows/npm-run-script.yml
@@ -149,20 +149,20 @@ defaults:
 jobs:
   script:
     name: NPM Script
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
     - name: Download Artifact
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       if: ${{ inputs.download-artifact && !inputs.download-artifact-unzip }}
       with:
         path: ${{ inputs.download-artifact-path }}
         name: ${{ inputs.download-artifact-name }}
 
     - name: Download Artifact (zipped)
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       if: ${{ inputs.download-artifact && inputs.download-artifact-unzip }}
       with:
         path: '.'
@@ -175,7 +175,7 @@ jobs:
         unzip -qo ${{ github.workspace }}/artifact-${{ github.sha }}.zip -d ${{ inputs.download-artifact-path }}
 
     - name: Setup Node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
       with:
         node-version: ${{ inputs.node-version }}
         node-version-file: ${{ inputs.node-version-file }}
@@ -197,7 +197,7 @@ jobs:
         npm config set $URL/:_authToken ${{inputs.private-registry-token}}
 
     - name: Cache dependencies
-      uses: actions/cache@v5
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
       id: cache-modules
       with:
         path: ${{ inputs.working-directory }}/node_modules
@@ -227,7 +227,7 @@ jobs:
 
     - name: Upload Artifact
       if: ${{ inputs.upload-artifact && !inputs.upload-artifact-zipped }}
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         retention-days: ${{ inputs.artifact-retention-days }}
         path: ${{ inputs.upload-artifact-path }}
@@ -235,7 +235,7 @@ jobs:
 
     - name: Upload Zipped Artifact
       if: ${{ inputs.upload-artifact && inputs.upload-artifact-zipped }}
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         retention-days: ${{ inputs.artifact-retention-days }}
         path: ${{ github.workspace }}/artifact-${{ github.sha }}.zip

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -26,12 +26,12 @@ jobs:
     name: Semantic Release
     permissions:
       contents: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.semantic.outputs.new_release_version }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         fetch-depth: 0
         persist-credentials: false
@@ -40,7 +40,7 @@ jobs:
       run: echo "GITHUB_BRANCH=$(echo $GITHUB_REF | sed 's/refs\/heads\///g')" >> $GITHUB_ENV
 
     - name: Semantic Release
-      uses: cycjimmy/semantic-release-action@v6
+      uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 # v6
       id: semantic
       with:
         branches: ${{ env.GITHUB_BRANCH }}


### PR DESCRIPTION
## Automated workflow updates

- Enforce runners: ubuntu-latest → ubuntu-24.04 | Enforce job timeouts: added timeout-minutes: 60 | Pin actions to SHA: actions/checkout@v6.0.2 (v6)
- Enforce runners: ubuntu-latest → ubuntu-24.04 | Enforce job timeouts: added timeout-minutes: 60 | Pin actions to SHA: actions/checkout@v6.0.2 (v6), actions/setup-node@v6.3.0 (v6), lewagon/wait-on-check-action@v1.6.0 (v1)
- Enforce runners: ubuntu-latest → ubuntu-24.04 | Enforce job timeouts: added timeout-minutes: 60
- Enforce runners: ubuntu-latest → ubuntu-24.04 | Enforce job timeouts: added timeout-minutes: 60 | Pin actions to SHA: actions/checkout@v6.0.2 (v6), actions/setup-node@v6.3.0 (v6)
- Enforce runners: ubuntu-latest → ubuntu-24.04 | Enforce job timeouts: added timeout-minutes: 60 | Pin actions to SHA: actions/checkout@v6.0.2 (v6), actions/setup-node@v6.3.0 (v6), actions/cache@v5.0.4 (v5), actions/upload-artifact@v7.0.0 (v7)
- Enforce runners: ubuntu-latest → ubuntu-24.04 | Enforce job timeouts: added timeout-minutes: 60 | Pin actions to SHA: actions/checkout@v6.0.2 (v6), actions/setup-node@v6.3.0 (v6), actions/cache@v5.0.4 (v5), actions/download-artifact@v8.0.1 (v8)
- Enforce runners: ubuntu-latest → ubuntu-24.04 | Enforce job timeouts: added timeout-minutes: 60 | Pin actions to SHA: actions/checkout@v6.0.2 (v6), actions/download-artifact@v8.0.1 (v8), actions/download-artifact@v8.0.1 (v8), actions/setup-node@v6.3.0 (v6), actions/cache@v5.0.4 (v5), actions/upload-artifact@v7.0.0 (v7), actions/upload-artifact@v7.0.0 (v7)
- Enforce runners: ubuntu-latest → ubuntu-24.04 | Enforce job timeouts: added timeout-minutes: 60 | Pin actions to SHA: actions/checkout@v6.0.2 (v6), cycjimmy/semantic-release-action@v6.0.0 (v6)

---
*Generated. Review carefully before merging.*